### PR TITLE
Store object key in details

### DIFF
--- a/AWS_bucket/vgp_upload_to_cloud.py
+++ b/AWS_bucket/vgp_upload_to_cloud.py
@@ -163,8 +163,9 @@ def main(path, profile, species_name, species_id, datatype, tissue=None):
                                     "container": "{region}:{bucket}".format(region='us-east-1', bucket=VGP_BUCKET),
                                     "object": object
                                     },
-                                'details': {'object-key': object}
-                                })
+                                'details': {'container': VGP_BUCKET,
+                                            'object': object}
+                                  })
         print('Associated object {obj} with DNAnexus file {file}'.format(obj=object, file=file['id']))
 
 if __name__ == '__main__':

--- a/AWS_bucket/vgp_upload_to_cloud.py
+++ b/AWS_bucket/vgp_upload_to_cloud.py
@@ -162,7 +162,8 @@ def main(path, profile, species_name, species_id, datatype, tissue=None):
                                 'symlinkPath': {
                                     "container": "{region}:{bucket}".format(region='us-east-1', bucket=VGP_BUCKET),
                                     "object": object
-                                    }
+                                    },
+                                'details': {'object-key': object}
                                 })
         print('Associated object {obj} with DNAnexus file {file}'.format(obj=object, file=file['id']))
 


### PR DESCRIPTION
"details" in a DNAnexus file are an immutable form of metadata. Adding the bucket name and object key metadata with the Dnanexus link will ensure consistent mapping back to the AWS drive object even if files move around the DNAnexus platform, and will make it easier to sync DNAnexus with the AWS drive.