### PR TITLE
Falcon 2019 jan23 update

### DIFF
--- a/dx_workflows/vgp_falcon_and_unzip_assembly_workflow/Readme.md
+++ b/dx_workflows/vgp_falcon_and_unzip_assembly_workflow/Readme.md
@@ -1,0 +1,8 @@
+FALCON and FALCON-Unzip Assembly
+# Update note
+## 2018-Jan-22 update
+- update to Falcon falcon-2018.31.08-03.06
+- change default instance type Unzip stage 3 to mem4_ssd1_x32
+- fix jellyfish/genomescope incorrect link from Daligner stage2 to stage1
+- make dazzler name different between standard, tanmask, and repmask
+- upgrade Unzip stage 5 to support V6 chem using SMRTlink 6.0.0.47841

--- a/dx_workflows/vgp_falcon_and_unzip_assembly_workflow/Readme.md
+++ b/dx_workflows/vgp_falcon_and_unzip_assembly_workflow/Readme.md
@@ -1,8 +1,13 @@
-FALCON and FALCON-Unzip Assembly
-# Update note
-## 2018-Jan-22 update
+# FALCON and FALCON-Unzip Assembly
+## Update note
+
+**2018-Jan-23 update**
 - update to Falcon falcon-2018.31.08-03.06
-- change default instance type Unzip stage 3 to mem4_ssd1_x32
+- change default instance type Unzip stage 3 to mem4_ssd1_x128
 - fix jellyfish/genomescope incorrect link from Daligner stage2 to stage1
-- make dazzler name different between standard, tanmask, and repmask
-- upgrade Unzip stage 5 to support V6 chem using SMRTlink 6.0.0.47841
+- make dazzler name different among standard, tanmask, and repmask
+- upgrade Unzip stage 5 to support V6 chemistry using SMRTlink 6.0.0.47841
+- change parameter for Falcon stage 1 from -k16 -e0.70 -s1000 -l1000 -h64 -w7 to -k14 -e0.75 -s100 -l2500 -h240 -w8 and for stage 2 from -k20 -e.96 -s1000 -t32 -l2500 -h256 to -k24 -e.90 -s100 -l1000 -h600. 
+
+Backward incompatibility note:
+- dazzler db created by this version of workflow with _tan and _mask cannot be used with older version of "HPC REPmask", "Daligner for PacBio's Falcon", or "Falcon_asm" apps/applets. However, output from old version of apps/applets would work fine for the new version (this version).

--- a/dx_workflows/vgp_falcon_and_unzip_assembly_workflow/dxworkflow.json
+++ b/dx_workflows/vgp_falcon_and_unzip_assembly_workflow/dxworkflow.json
@@ -1,6 +1,7 @@
 {
-  "name": "vgp_falcon_and_unzip_assembly",
+  "name": "vgp_falcon_and_unzip_assembly_workflow",
   "title": "Falcon and Falcon Unzip Assembly Workflow",
+  "summary": "VGP1.5 Falcon and Falcon-Unzip workflow",
   "stages": [
     {
       "id": "bam_to_fasta",
@@ -11,7 +12,7 @@
     {
       "id": "falcon_0_create_dazzler_db",
       "name": "Create Raw Reads Dazzler DB",
-      "executable": "app-create_dazzler_db/1.9.3",
+      "executable": "app-create_dazzler_db/2.0.0",
       "folder": "stage_1",
       "input": {
         "include_secondary_reads": true,
@@ -56,7 +57,7 @@
     {
       "id": "falcon_0_hpc_tanmask",
       "name": "Raw Reads HPC TANmask",
-      "executable": "app-hpc_tanmask/1.9.1",
+      "executable": "app-hpc_tanmask/2.0.0",
       "folder": "stage_1",
       "input": {
         "dazzler_db": {
@@ -76,7 +77,7 @@
     {
       "id": "falcon_0_hpc_repmask",
       "name": "Raw Reads HPC REPmask",
-      "executable": "app-hpc_repmask/1.9.2",
+      "executable": "app-hpc_repmask/2.0.0",
       "folder": "stage_1",
       "input": {
         "dazzler_db": {
@@ -103,7 +104,7 @@
     {
       "id": "falcon_0_hpc_daligner",
       "name": "Falcon Raw Reads Daligner",
-      "executable": "app-fc_hpc_daligner/1.9.0",
+      "executable": "app-fc_hpc_daligner/2.0.0",
       "folder": "stage_1",
       "input": {
         "trim": false,
@@ -135,6 +136,23 @@
       }
     },
     {
+      "id": "falcon_1_jellyfish",
+      "name": "Preads Jellyfish and GenomeScope",
+      "executable": "app-jellyfish_and_genomescope/1.0.0",
+      "folder": "stage_1/genome_scope",
+      "input": {
+        "mer_length": 21,
+        "sequences_fastx": [
+          {
+            "$dnanexus_link": {
+              "outputField": "consensus_fastas",
+              "stage": "falcon_0_hpc_daligner"
+            }
+          }
+        ]
+      }
+    },
+    {
       "id": "falcon_1_calc_distribution",
       "name": "Raw Reads Calculate Read Length Distribution",
       "executable": "app-calculate_read_length_distribution/1.9.2",
@@ -159,7 +177,7 @@
     {
       "id": "falcon_1_create_dazzler_db",
       "name": "Falcon Preads Dazzler DB",
-      "executable": "app-create_dazzler_db/1.9.3",
+      "executable": "app-create_dazzler_db/2.0.0",
       "folder": "stage_2",
       "input": {
         "include_secondary_reads": true,
@@ -189,7 +207,7 @@
     },
     {
       "id": "falcon_1_hpc_tanmask",
-      "executable": "app-hpc_tanmask/1.9.1",
+      "executable": "app-hpc_tanmask/2.0.0",
       "name": "Falcon Preads HPC TANmask",
       "folder": "stage_1",
       "input": {
@@ -209,7 +227,7 @@
     },
     {
       "id": "falcon_1_hpc_repmask",
-      "executable": "app-hpc_repmask/1.9.2",
+      "executable": "app-hpc_repmask/2.0.0",
       "name": "Falcon Preads HPC REPmask",
       "folder": "stage_1",
       "input": {
@@ -237,7 +255,7 @@
     {
       "id": "falcon_1_hpc_daligner",
       "name": "Falcon Preads Daligner",
-      "executable": "app-fc_hpc_daligner/1.9.0",
+      "executable": "app-fc_hpc_daligner/2.0.0",
       "folder": "stage_2",
       "input": {
         "generate_consensus_fastas": "None",
@@ -265,26 +283,9 @@
         }
       }
     },
-  {
-      "id": "falcon_2_jellyfish",
-      "name": "Preads Jellyfish and GenomeScope",
-      "executable": "app-jellyfish_and_genomescope/1.0.0",
-      "folder": "stage_2/genome_scope",
-      "input": {
-        "mer_length": 21,
-        "sequences_fastx": [
-          {
-            "$dnanexus_link": {
-              "outputField": "consensus_fastas",
-              "stage": "falcon_1_hpc_daligner"
-            }
-          }
-        ]
-      }
-    },
     {
       "id": "falcon_2_asm",
-      "executable": "app-falcon_asm/1.9.1",
+      "executable": "app-falcon_asm/2.0.0",
       "name": "Falcon Assembly",
       "folder": "stage_3",
       "input": {
@@ -446,7 +447,7 @@
     {
       "id": "unzip_2_haplotype_assembly",
       "name": "Unzip Haplotype Assembly",
-      "executable": "app-unzip_2_haplotype_assembly/1.0.2",
+      "executable": "app-unzip_2_haplotype_assembly/1.0.3",
       "folder": "unzip_stage_3",
       "input": {
         "sg_edges_list": {
@@ -565,7 +566,7 @@
     {
       "id": "unzip_4_haplotype_polish",
       "name": "Unzip Haplotype Polish",
-      "executable": "app-unzip_4_haplotype_polish/1.0.6",
+      "executable": "app-unzip_4_haplotype_polish/1.1.0",
       "folder": "unzip_stage_5",
       "input": {
         "all_p_ctg": {

--- a/dx_workflows/vgp_falcon_and_unzip_assembly_workflow/dxworkflow.json
+++ b/dx_workflows/vgp_falcon_and_unzip_assembly_workflow/dxworkflow.json
@@ -66,7 +66,7 @@
             "stage": "falcon_0_create_dazzler_db"
           }
         },
-        "advanced_options": "-k16 -e0.70 -s1000 -l1000 -h64 -w7 "
+        "advanced_options": "-k14 -e0.75 -s100 -l2500 -h240 -w8 "
       },
       "systemRequirements": {
         "*": {
@@ -93,7 +93,7 @@
           }
         },
         "use_mask": true,
-        "advanced_options": "-k16 -e0.70 -s1000 -l1000 -h64 -w7 "
+        "advanced_options": "-k14 -e0.75 -s100 -l2500 -h240 -w8 "
       },
       "systemRequirements": {
         "*": {
@@ -108,7 +108,7 @@
       "folder": "stage_1",
       "input": {
         "trim": false,
-        "daligner_arguments": "-k16 -e0.70 -s1000 -t16 -l1000 -h64 -w7 ",
+        "daligner_arguments": "-k14 -e0.75 -s100 -l2500 -h240 -w8 ",
         "sync_time": 1,
         "dazzler_db": {
           "$dnanexus_link": {
@@ -217,7 +217,7 @@
             "stage": "falcon_1_create_dazzler_db"
           }
         },
-        "advanced_options": "-k20 -e.96 -s1000 -l2500 -h256 "
+        "advanced_options": "-k24 -e.90 -s100 -l1000 -h600 "
       },
       "systemRequirements": {
         "*": {
@@ -244,7 +244,7 @@
           }
         },
         "use_mask": true,
-        "advanced_options": "-k20 -e.96 -s1000 -l2500 -h256 "
+        "advanced_options": "-k24 -e.90 -s100 -l1000 -h600 "
       },
       "systemRequirements": {
         "*": {
@@ -275,7 +275,7 @@
         },
         "file_prefix": "preads",
         "num_threads_per_daligner_job": 4,
-        "daligner_arguments": "-k20 -e.96 -s1000 -t32 -l2500 -h256 "
+        "daligner_arguments": "-k24 -e.90 -s100 -l1000 -h600 "
       },
       "systemRequirements": {
         "*": {

--- a/dx_workflows/vgp_falcon_and_unzip_workflow/Readme.md
+++ b/dx_workflows/vgp_falcon_and_unzip_workflow/Readme.md
@@ -1,1 +1,0 @@
-FALCON and FALCON-Unzip Assembly


### PR DESCRIPTION
- update to Falcon falcon-2018.31.08-03.06
- change default instance type Unzip stage 3 to mem4_ssd1_x128
- fix jellyfish/genomescope incorrect link from Daligner stage2 to stage1
- make dazzler name different among standard, tanmask, and repmask
- upgrade Unzip stage 5 to support V6 chemistry using SMRTlink 6.0.0.47841
- change parameter for Falcon stage 1 from -k16 -e0.70 -s1000 -l1000 -h64 -w7 to -k14 -e0.75 -s100 -l2500 -h240 -w8 and for stage 2 from -k20 -e.96 -s1000 -t32 -l2500 -h256 to -k24 -e.90 -s100 -l1000 -h600. 