### PR TITLE
update version to use app with higher memory

### DIFF
--- a/dx_workflows/vgp_falcon_and_unzip_assembly_workflow/Readme.md
+++ b/dx_workflows/vgp_falcon_and_unzip_assembly_workflow/Readme.md
@@ -1,6 +1,9 @@
 # FALCON and FALCON-Unzip Assembly
 ## Update note
 
+**2019-Feb-25 update**
+- change default instance type for Align and Phase
+
 **2019-Feb-15 update**
 - start using TANmask2.0.0 and REPmask2.0.1 after testing on 3 large genomes
 - fix discrepancy of unzip_stage_0 app and github. The old version miss logic to handle missing ref/read. New version is unzip_stage_0 track_read 1.1.0

--- a/dx_workflows/vgp_falcon_and_unzip_assembly_workflow/dxworkflow.json
+++ b/dx_workflows/vgp_falcon_and_unzip_assembly_workflow/dxworkflow.json
@@ -403,7 +403,7 @@
     {
       "id": "unzip_1_align_and_phase",
       "name": "Unzip Align and Phase",
-      "executable": "app-unzip_1_align_and_phase/1.0.1",
+      "executable": "app-unzip_1_align_and_phase/1.0.2",
       "folder": "unzip_stage_2",
       "input": {
         "raw_read_ids": {

--- a/dx_workflows/vgp_falcon_and_unzip_assembly_workflow/dxworkflow.json
+++ b/dx_workflows/vgp_falcon_and_unzip_assembly_workflow/dxworkflow.json
@@ -442,6 +442,11 @@
             "stage": "unzip_0_track_reads"
           }
         }
+      },
+      "systemRequirements": {
+        "*": {
+          "instanceType": "mem1_ssd1_x32"
+        }
       }
     },
     {


### PR DESCRIPTION
This is the workflow change for the Falcon-unzip align and phase app update.

See the rational below or in genome_assembly repo PR.
I update default instance type based on 3 VGP genomes which got into out of memory. The mem1_ssd1_x32 is proof to be sufficient, so we don't need mem3_ssd1_x16. This should be working fine with not so much more cost because download and parallelization step go faster.